### PR TITLE
Fix quotes closing in word after special char

### DIFF
--- a/src/closebrackets.ts
+++ b/src/closebrackets.ts
@@ -213,7 +213,7 @@ function handleSame(state: EditorState, token: string, allowTriple: boolean) {
               range: EditorSelection.cursor(pos + token.length)}
     } else if (state.charCategorizer(pos)(next) != CharCategory.Word) {
       let prev = state.sliceDoc(pos - 1, pos)
-      if (prev != token && state.charCategorizer(pos)(prev) != CharCategory.Word)
+      if (prev != token && state.charCategorizer(pos)(prev) == CharCategory.Space)
         return {changes: {insert: token + token, from: pos},
                 effects: closeBracketEffect.of(pos + token.length),
                 range: EditorSelection.cursor(pos + token.length)}

--- a/test/test-closebrackets.ts
+++ b/test/test-closebrackets.ts
@@ -85,6 +85,8 @@ describe("closeBrackets", () => {
     ist(!insertBracket(s("ab", 1), "'"))
     ist(!insertBracket(s("ab", 2), "'"))
     ist(!insertBracket(s("ab", 0), "'"))
+    ist(!insertBracket(s("'ab", 3), "'"));
+    ist(!insertBracket(s("'ab!", 4), "'"));
   })
 
   const syntax = StreamLanguage.define({


### PR DESCRIPTION
Hey Marijn!

Correct me if I'm wrong but I believe I found a bug in this extension. Looks like quotes/brackets don't get closed if inserted in the middle of a word (i.e. in front of any character but white space) UNLESS the opening character is placed in front of a special char such as `!`, `?`, etc.

Take the following example:
- `print("Hi`
- Insert `"` at the end of the string
- See: `print("Hi"` (which is correct)

However, if you take the same string and add an `!` you get the following result:
- `print("Hi!`
- Insert `"` at the end of the string
- See: `print("Hi!""` (which is incorrect)

I also added a test case (which was failing on main) to demonstrate what I mean.

The docs (https://codemirror.net/6/docs/ref/#closebrackets) lead me to believe that this behavior is unintentional since all it says is:
> Characters in front of which newly opened brackets are automatically closed. Closing always happens in front of whitespace. Defaults to ")]}'\":;>".

and there's no mention of an exception being made for special characters like `!`.